### PR TITLE
Force explicit setting of cache server address

### DIFF
--- a/runner/templates/_helpers.tpl
+++ b/runner/templates/_helpers.tpl
@@ -43,11 +43,3 @@ kubernetes
 docker
 {{- end -}}
 {{- end -}}
-
-{{- define "minio.fullname" -}}
-{{- if .Values.cache.serverAddress -}}
-{{ .Values.cache.serverAddress }}
-{{- else }}
-{{- printf "%s-minio-svc" .Release.Name | trunc 63 | trimSuffix "-" -}}
-{{- end -}}
-{{- end -}}

--- a/runner/templates/configmap.yaml
+++ b/runner/templates/configmap.yaml
@@ -64,7 +64,7 @@ data:
       {{ if .Values.cache.enabled -}}
       [runners.cache]
         Type = {{ .Values.cache.type | quote }}
-        ServerAddress = "{{ template "minio.fullname" . }}:9000"
+        ServerAddress = {{ .Values.cache.serverAddress | quote }}
         Insecure = {{ default "false" .Values.cache.insecure }}
         AccessKey = {{ .Values.cache.accessKey | quote }}
         SecretKey = {{ .Values.cache.secretKey | quote }}

--- a/runner/templates/configmap.yaml
+++ b/runner/templates/configmap.yaml
@@ -64,9 +64,9 @@ data:
       {{ if .Values.cache.enabled -}}
       [runners.cache]
         Type = {{ .Values.cache.type | quote }}
-        ServerAddress = {{ .Values.cache.serverAddress | quote }}
+        ServerAddress = {{ required "Cache server address is required." .Values.cache.serverAddress | quote }}
         Insecure = {{ default "false" .Values.cache.insecure }}
-        AccessKey = {{ .Values.cache.accessKey | quote }}
-        SecretKey = {{ .Values.cache.secretKey | quote }}
+        AccessKey = {{ required "Cache access key is required." .Values.cache.accessKey | quote }}
+        SecretKey = {{ required "Cache secret key is required." .Values.cache.secretKey | quote }}
         BucketName = {{ default "runner" .Values.cache.bucketName | quote }}
       {{- end }}


### PR DESCRIPTION
Fixes #4 

Also made `cache.serverAddress`, `cache.accessKey` and `cache.secretKey` required when cache is enabled.