### PR TITLE
refactor metricsServer implementation

### DIFF
--- a/runner/Chart.yaml
+++ b/runner/Chart.yaml
@@ -1,5 +1,5 @@
 name: runner
-version: 0.4.2
+version: 0.4.3
 description: GitLab-ci runner
 keywords:
 - git

--- a/runner/templates/configmap.yaml
+++ b/runner/templates/configmap.yaml
@@ -15,7 +15,7 @@ data:
     sentry_dsn = "{{ .Values.sentryDSN }}"
     {{ end -}}
     {{ if .Values.metricsServer -}}
-    metrics_server = {{ .Values.metricsServer -}}
+    metrics_server = "0.0.0.0:9252"
     {{ end -}}
 
     [[runners]]

--- a/runner/templates/deployment.yaml
+++ b/runner/templates/deployment.yaml
@@ -20,11 +20,21 @@ spec:
         heritage: "{{ .Release.Service }}"
       annotations:
         checksum/config-map: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+      {{- if .Values.metricsServer }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9252"
+      {{- end }}
     spec:
       containers:
       - name: {{ template "fullname" . }}
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: {{ default "" .Values.imagePullPolicy | quote }}
+      {{- if .Values.metricsServer }}
+        ports:
+        - containerPort: 9252
+          name: metrics
+          protocol: TCP
+      {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         volumeMounts:
@@ -39,4 +49,4 @@ spec:
       - name: config
         configMap:
           name: {{ template "fullname" . }}
-{{ end}}
+{{ end }}

--- a/runner/values.yaml
+++ b/runner/values.yaml
@@ -34,7 +34,9 @@ resources:
 # registrationToken: ""
 
 # sentryDSN: ""
-# metricsServer: ""
+
+# enable the metrics server
+# metricsServer: true
 
 executor:
   ## Configure executor type


### PR DESCRIPTION
This pull request refactors the current metricsServer implementation of the runner chart for dead simple integration with a Prometheus monitoring server running within k8s.

The implementation is rather opinionated, given the use case envisioned (passing metrics to Prometheus within a running k8s) is fairly straight forward. While it could be less opinionated, I personally do not really see much value in exposing, e.g., variable ports on which to serve the metrics on. 

The host:port combination chosen in the PR are [the gitlab runner defaults](https://docs.gitlab.com/runner/monitoring/README.html). 

BTW, thanks for your great charts!