### PR TITLE
Fix multiline annotations in template deployment.yaml

### DIFF
--- a/victoria-metrics/templates/deployment.yaml
+++ b/victoria-metrics/templates/deployment.yaml
@@ -21,10 +21,10 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "victoria-metrics.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-    {{- if .Values.podAnnotations }}
+{{- if .Values.podAnnotations }}
       annotations:
-        {{ toYaml .Values.podAnnotations | indent 8 | trim }}
-    {{- end }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}

--- a/victoria-metrics/templates/deployment.yaml
+++ b/victoria-metrics/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     {{- if .Values.podAnnotations }}
       annotations:
-    {{ toYaml .Values.podAnnotations | indent 4 }}
+        {{ toYaml .Values.podAnnotations | indent 8 | trim }}
     {{- end }}
     spec:
       containers:


### PR DESCRIPTION
I'm try define:
```
podAnnotations:
  prometheus.io/port: "8080"
  prometheus.io/scrape: "true"
```

and get error from helm
```
helm upgrade victoria-metrics lwolf/victoria-metrics -f values-vicoria-metrics.yaml
Error: UPGRADE FAILED: v1beta2.Deployment: Spec: v1beta2.DeploymentSpec: Template: v1.PodTemplateSpec: ObjectMeta: v1.ObjectMeta: Annotations: ReadString: expects " or n, but found 8, error found in #10 byte of ...|io/port":8080},"crea|..., bigger context ...|{"metadata":{"annotations":{"prometheus.io/port":8080},"creationTimestamp":null,"labels":{"app.kuber|...
```