### PR TITLE
added imagePullSecrets configuration availability for victoria-metric

### DIFF
--- a/victoria-metrics/Chart.yaml
+++ b/victoria-metrics/Chart.yaml
@@ -13,4 +13,4 @@ maintainers: # (optional)
     email: ipaq.lw@gmail.com
     url: https://github.com/lwolf
 name: victoria-metrics
-version: 0.1.8
+version: 0.1.9

--- a/victoria-metrics/templates/deployment.yaml
+++ b/victoria-metrics/templates/deployment.yaml
@@ -100,3 +100,6 @@ spec:
       {{- else }}
         emptyDir: {}
       {{ end }}
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.imagePullSecrets | trim | nindent 6 }}
+      {{- end }}


### PR DESCRIPTION
Hello!
let me thank you for your charts, especially for the victoria-metrics one, we use it at least since 2019
Can you please add the imagePullSecrets according to my pull request?
As you know docker team changed their image pulling policy and our team forced to pull images from our private repository. That is why we should use  the imagePullSecrets.